### PR TITLE
Small modification to template for aws.spc from "aws_all" to "aws"

### DIFF
--- a/aws/steampipe.gospc
+++ b/aws/steampipe.gospc
@@ -1,6 +1,6 @@
 ### {{$.Marker}}_START ###
 
-connection "aws_all" {
+connection "aws" {
   plugin      = "aws"
   type        = "aggregator"
   connections = [{{.AllAccountsString}}]


### PR DESCRIPTION
After beating my head against a wall for a while trying to get steampipe dashboards and similar tools across multiple accounts, I learned that chancing this:

```
connection "aws_all" {
  plugin      = "aws"
  type        = "aggregator"
  connections = ["aws_126801570222", "aws_204877948071", "aws_926864421402", "aws_818567902521", "aws

```
to

```
connection "aws" {
  plugin      = "aws"
  type        = "aggregator"
  connections = ["aws_126801570222", "aws_204877948071", "aws_926864421402", "aws_818567902521", "aws
```

allows things like this to work across all (or a subset with multiple if the spc is edited) AWS accounts without having to prefix the SQL table with the profile/account.
