### PR TITLE
Add Kion integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 main
 aiphelper
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# AIP SSO Helper
+# AIP Profile Helper
 
-This utility helps set up various CLI tools with access to multiple cloud accounts. For AWS it uses AWS SSO to sign you in and gather information about the accounts you have access to.
+This utility helps set up various CLI tools with access to all your cloud accounts. For AWS, it will create AWS CLI (profiles)[https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#cli-configure-files-format] for each account and role you have access to. It also creates Steampipe connectors for each profile, and an aggregate connector for each unique role.
 
 ## Usage
 
 ```
 Usage:
-  main [OPTIONS] <aws | azure>
+  aiphelper [OPTIONS] <aws | azure>
 
 Application Options:
-  -V, --version  aiphelper Version
+  -V, --version       aiphelper Version
+  -d, --debug         Enable debug logging
+      --kion-url=     Kion URL to use for profile generation (env: KION_URL)
+      --kion-apikey=  Kion API token for authentication (env: KION_APIKEY)
 
 Help Options:
   -h, --help  Show this help message
@@ -19,6 +22,10 @@ Available commands:
   azure  Initialize Azure
 
 [aws command options]
+      Account Source Options (exactly one required):
+          --from-sso     Use AWS Identity Center to get account list
+          --from-kion    Use Kion API to get account list
+
           --sso-start-url=  AWS SSO Start URL (default: https://aggie-innovation-platform.awsapps.com/start)
           --sso-region=     AWS SSO Region (default: us-east-2)
           --sso-role-name=  SSO Role To Assume (must be the same across all accounts) (default: AdministratorAccess)
@@ -37,22 +44,51 @@ Available commands:
 Example usage:
 
 ```
-aiphelper aws # Default regions
-aiphelper aws --regions us-east-1,us-west-1 
+# Default regions
+aiphelper aws
+
+# Specific regions
+aiphelper aws --regions us-east-1,us-east-2
+
+# AWS CLI use
+aws ec2 describe-instances --profile div_dept_my_account_001_readonlyaccess --filters "Name=tag:Environment,Values=test"
+
+# Steampipe use
+steampipe query 'select * from aws_div_dept_my_account_001_readonlyaccess.ec2_instance where tags["Environment"] = "test"'
+
+# Steampipe with aggregate connector
+steampipe query 'select * from aws_all_readonlyaccess.ec2_instance where tags["Environment"] = "test"'
 
 ```
 
 ## AWS
 
-`aiphelper` will create an aws profile for each account you have access to based on the account's display name. To use a profile, pass the profile name to the aws cli:
+`aiphelper` will create an aws profile for each account and role you have access to based on the account's display name and the role name. The profile name will be in the format `<account_name>_<role_name>` where both account and role names are normalized to be lowercase with underscores, and truncated to 63 characters.
 
-```
-aws ec2 describe-instances --profile=div_dept_my_account_002
-```
+For example, if you have access to the account `Div Dept My Account 002` with two roles, `AdministratorAccess` and `ReadOnlyAccess`, two profiles will be created: `div_dept_my_account_002_administratoraccess` and `div_dept_my_account_002_readonlyaccess`.
 
-Either a normalized account name (all lowercase and underscores) or the account ID can be used as the profile name.
+The profiles will be created in the AWS CLI config file, which is typically located at `~/.aws/config`. If you have custom profiles, they will be preserved. `aiphelper` will only manage the file contents between its file markers, `### AIPHELPER_MARKER_[START|END] ###`
 
-If you already have an AWS CLI SSO token that matches the SSO URL and region, it will be used. Otherwise, a bew device flow authentication will be started using the SSO parameters, and the token will be cached to disk for further AWS CLI operations.
+
+### Kion Integration
+
+`aiphelper` can be used to generate AWS profiles from Kion that use the `kion-cli` to generate short-term credentials transparently. This is useful for directly using the AWS CLI with Kion-managed accounts, as well as with tools that use the AWS CLI config file, such as Steampipe. Kion is the default account source, but you can explicitly specify it with the `--from-kion` option.
+
+To use this feature, you must have the `kion-cli` tool installed and configured. See the [Kion CLI documentation](https://github.com/kionsoftware/kion-cli) for more information.
+
+The Kion URL and API key can be set using the `--kion-url` and `--kion-apikey` options or the environment variables `KION_URL` and `KION_APIKEY`. `aiphelper` does not yet support sharing Kion API credentials with `kion-cli`, but this feature is planned for a future release.
+
+### AWS Identity Center (SSO)
+
+`aiphelper` can be used to generate AWS profiles from AWS Identity Center. AWS Identity Center is not used for AIP customer access, but is still used for some internal and staff accounts. Please use the Kion integration if you are an AIP customer.
+
+To use Identity Center as the account source, use the `--from-sso` option. This will use the AWS CLI SSO configuration to generate profiles for each account and role you have access to.
+
+However, unlike with the Kion integration, the SSO integration only creates supports a single role per account, specified by the `--sso-role-name` option. Two profiles will be created per account in the formats `aws_<account_name>` and `aws_<account_number>`. 
+
+For steampipe, A single aggregate connector `aws_all` will be created with one of each AWS account, using the `aws_<accountnumber>` connectors.
+
+If you already have an AWS CLI SSO token that matches the SSO URL and region, it will be used. Otherwise, a new device flow authentication will be started using the SSO parameters, and the token will be cached to disk for further AWS CLI operations.
 
 ## Azure
 
@@ -66,7 +102,15 @@ If you need to specify an authentication method, such as to use CLI or ENV crede
 
 ### AWS
 
-`aiphelper` will create a steampipe connector for each AWS profile and for each region specified (defaults to the AWS CLI default values). This will result in two connectors for each AWS account: `aws_<normalizedname>` and `aws_<accountnumber>`. It will also create an aggregate connector `aws_all` with one of each AWS account, using the `aws_<accountnumber>` connector. 
+`aiphelper` will create one Steampipe connector for each AWS profile for each region specified, defaulting to the AWS CLI default region search order. The connector names will be in the format `aws_<account_name>_<role_name>` where both account and role names are normalized to be lowercase with underscores, and truncated to 63 characters.
+
+When using Kion as an account source, aggregate connectors will be created for each unique role. The connector names will be in the format `aws_all_<role_name>` where the role name is normalized to be lowercase with underscores, and truncated to 63 characters. The aggregate connectors will allow you to query multiple accounts at once, limited to the accounts that role has access to.
+
+For example, if you have access to the accounts `Div Dept My Account 001` and `Div Dept My Account 002` with a `ReadOnlyAccess` role, an aggregate connector will be created as `aws_all_readonlyaccess` which will use both the `aws_div_dept_my_account_001_readonlyaccess` and `aws_div_dept_my_account_002_readonlyaccess` connectors.
+
+If you are using AWS Identity Center as the account source, only one aggregate connector will be created, `aws_all`, which will use all the AWS accounts you have access to. 
+
+The Steampipe configuration file will be created in the Steampipe config directory, which is typically located at `~/.steampipe/config/aws.spc`. If you have custom connectors or settings, they will be preserved. `aiphelper` will only manage the file contents between its file markers, `### AIPHELPER_MARKER_[START|END] ###`
 
 ### Azure
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ aws ec2 describe-instances --profile div_dept_my_account_001_readonlyaccess --fi
 steampipe query 'select * from aws_div_dept_my_account_001_readonlyaccess.ec2_instance where tags["Environment"] = "test"'
 
 # Steampipe with aggregate connector
-steampipe query 'select * from aws_all_readonlyaccess.ec2_instance where tags["Environment"] = "test"'
+steampipe query 'select * from aws_role_readonlyaccess.ec2_instance where tags["Environment"] = "test"'
 
 ```
 
@@ -86,7 +86,7 @@ To use Identity Center as the account source, use the `--from-sso` option. This 
 
 However, unlike with the Kion integration, the SSO integration only creates supports a single role per account, specified by the `--sso-role-name` option. Two profiles will be created per account in the formats `aws_<account_name>` and `aws_<account_number>`. 
 
-For steampipe, A single aggregate connector `aws_all` will be created with one of each AWS account, using the `aws_<accountnumber>` connectors.
+For steampipe, A single aggregate connector `aws` will be created with one of each AWS account, using the `aws_<account_number>` connectors.
 
 If you already have an AWS CLI SSO token that matches the SSO URL and region, it will be used. Otherwise, a new device flow authentication will be started using the SSO parameters, and the token will be cached to disk for further AWS CLI operations.
 
@@ -104,17 +104,17 @@ If you need to specify an authentication method, such as to use CLI or ENV crede
 
 `aiphelper` will create one Steampipe connector for each AWS profile for each region specified, defaulting to the AWS CLI default region search order. The connector names will be in the format `aws_<account_name>_<role_name>` where both account and role names are normalized to be lowercase with underscores, and truncated to 63 characters.
 
-When using Kion as an account source, aggregate connectors will be created for each unique role. The connector names will be in the format `aws_all_<role_name>` where the role name is normalized to be lowercase with underscores, and truncated to 63 characters. The aggregate connectors will allow you to query multiple accounts at once, limited to the accounts that role has access to.
+When using Kion as an account source, aggregate connectors will be created for each unique role. The connector names will be in the format `aws_role_<role_name>` where the role name is normalized to be lowercase with underscores, and truncated to 63 characters. The aggregate connectors will allow you to query multiple accounts at once, limited to the accounts that role has access to.
 
-For example, if you have access to the accounts `Div Dept My Account 001` and `Div Dept My Account 002` with a `ReadOnlyAccess` role, an aggregate connector will be created as `aws_all_readonlyaccess` which will use both the `aws_div_dept_my_account_001_readonlyaccess` and `aws_div_dept_my_account_002_readonlyaccess` connectors.
+For example, if you have access to the accounts `Div Dept My Account 001` and `Div Dept My Account 002` with a `ReadOnlyAccess` role, an aggregate connector will be created as `aws_role_readonlyaccess` which will use both the `aws_div_dept_my_account_001_readonlyaccess` and `aws_div_dept_my_account_002_readonlyaccess` connectors.
 
-If you are using AWS Identity Center as the account source, only one aggregate connector will be created, `aws_all`, which will use all the AWS accounts you have access to. 
+If you are using AWS Identity Center as the account source, only one aggregate connector will be created, `aws`, which will use all the AWS accounts you have access to. 
 
 The Steampipe configuration file will be created in the Steampipe config directory, which is typically located at `~/.steampipe/config/aws.spc`. If you have custom connectors or settings, they will be preserved. `aiphelper` will only manage the file contents between its file markers, `### AIPHELPER_MARKER_[START|END] ###`
 
 ### Azure
 
-`aiphelper` will create a steampipe connector for each Azure subscription it discovers. It will also create an aggregate connector `azure_all` with every Azure subscription.
+`aiphelper` will create a steampipe connector for each Azure subscription it discovers. It will also create an aggregate connector `azure` with every Azure subscription.
 
 ### Performance
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -33,6 +34,9 @@ import (
 //go:embed aws_config.tmpl
 var awsTemplateString string
 
+//go:embed aws_kion_config.tmpl
+var awsKionTemplateString string
+
 //go:embed steampipe.gospc
 var steampipeTemplateString string
 
@@ -44,7 +48,8 @@ type SSOCachedCredential struct {
 }
 
 type AWSAccountInfo struct {
-	NormalizedAccountName string
+	NormalizedAccountName   string
+	KionCloudAccessRoleName string
 	ssotypes.AccountInfo
 }
 
@@ -63,47 +68,74 @@ type AWSTemplateData struct {
 	Marker      string
 }
 
+type SteampipeRole struct {
+	RoleName              string
+	RoleProfileListString string
+}
+
 type SteampipeTemplateData struct {
 	Regions           []string
 	AccountList       []AWSAccountInfo
 	AllAccountsString string
 	RegionsString     string
+	RoleList          []SteampipeRole
 	Marker            string
 }
 
 func Init() {
-
 	awsTemplate = template.Must(template.New("awsTemplate").Parse(awsTemplateString))
+	awsKionTemplate := template.Must(template.New("awsTemplate").Parse(awsKionTemplateString))
 	steampipeTemplate = template.Must(template.New("steampipeTemplate").Parse(steampipeTemplateString))
 
 	awsTemplateData.Params = options
 
-	accessToken, cfg, err := authenticate()
-	if err != nil {
-		log.Fatalln(err)
-	}
+	var err error
 
-	// create sso client
-	ssoClient := sso.NewFromConfig(cfg)
-	// list accounts
-	fmt.Print("Fetching list of all accounts... ")
+	if options.FromKion {
+		// Switch to the Kion template when --from-kion is used
+		awsTemplate = awsKionTemplate
 
-	accountPaginator := sso.NewListAccountsPaginator(ssoClient, &sso.ListAccountsInput{
-		AccessToken: &accessToken,
-	})
+		// Get Kion URL and API key from global options
+		kionURL := utils.GetGlobalOption("kion-url")
+		kionApikey := utils.GetGlobalOption("kion-apikey")
 
-	for accountPaginator.HasMorePages() {
-		x, err := accountPaginator.NextPage(context.TODO())
+		// Get accounts from Kion
+		fmt.Println("Using Kion as the account source...")
+		accounts, err = GetAccountsFromKion(kionURL, kionApikey)
 		if err != nil {
-			fmt.Println(err)
+			log.Fatalf("Failed to get accounts from Kion: %v", err)
 		}
-		for _, account := range x.AccountList {
-			account := AWSAccountInfo{AccountInfo: account}
-			if len(options.Accounts.All) > 0 && !slices.Contains(options.Accounts.All, *account.AccountId) {
-				continue
+
+	} else {
+		// Use existing SSO logic
+		accessToken, cfg, err := authenticate()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		// create sso client
+		ssoClient := sso.NewFromConfig(cfg)
+		// list accounts
+		fmt.Print("Fetching list of all accounts from AWS Identity Center... ")
+
+		accountPaginator := sso.NewListAccountsPaginator(ssoClient, &sso.ListAccountsInput{
+			AccessToken: &accessToken,
+		})
+
+		for accountPaginator.HasMorePages() {
+			x, err := accountPaginator.NextPage(context.TODO())
+			if err != nil {
+				fmt.Println(err)
 			}
-			account.NormalizedAccountName = utils.SnakeCase(*account.AccountName)
-			accounts = append(accounts, account)
+			for _, account := range x.AccountList {
+				account := AWSAccountInfo{AccountInfo: account}
+				if len(options.Accounts.All) > 0 && !slices.Contains(options.Accounts.All, *account.AccountId) {
+					continue
+				}
+				fmt.Printf("Account: %s (%s)\n", *account.AccountName, *account.AccountId)
+				account.NormalizedAccountName = utils.SnakeCase(*account.AccountName)
+				accounts = append(accounts, account)
+			}
 		}
 	}
 
@@ -226,11 +258,13 @@ func updateAwsConfigFile() {
 	var awsTemplateBuffer bytes.Buffer
 
 	awsTemplateData.AccountList = accounts
+	utils.Debug("List of AWS accounts: %v\n", awsTemplateData.AccountList)
 	err = awsTemplate.Execute(&awsTemplateBuffer, awsTemplateData)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
+	utils.Debug("Writing AWS config file contents: %s\n", awsTemplateBuffer.String())
 	err = utils.CreateOrReplaceInFile(awsConfigFilePath, awsTemplateBuffer.String())
 
 	if err != nil {
@@ -246,8 +280,55 @@ func updateSteampipeAwsConfigFile() {
 
 	steampipeTemplateData.RegionsString = strings.Join(options.Regions.All, "\", \"")
 
+	// Create a map to group accounts by role
+	roleToAccounts := make(map[string][]string)
+
+	// Find all unique KionCloudAccessRoleName values and build lists of accounts for each role
 	for _, account := range accounts {
-		steampipeTemplateData.AllAccountsString = steampipeTemplateData.AllAccountsString + "\"aws_" + *account.AccountId + "\", "
+		roleName := account.KionCloudAccessRoleName
+		normalizedRoleName := strings.ToLower(roleName)
+		re := regexp.MustCompile(`[^a-z0-9_]`)
+		normalizedRoleName = re.ReplaceAllString(normalizedRoleName, "_")
+
+		if roleName != "" { // Only process accounts with role names (from Kion)
+			// Initialize the slice if this is the first account with this role
+			if _, exists := roleToAccounts[normalizedRoleName]; !exists {
+				roleToAccounts[normalizedRoleName] = []string{}
+			}
+
+			// Add this account's normalized name to the appropriate role's list
+			roleToAccounts[normalizedRoleName] = append(roleToAccounts[normalizedRoleName], account.NormalizedAccountName)
+		}
+	}
+
+	// Create role objects for the template
+	steampipeTemplateData.RoleList = []SteampipeRole{}
+	for roleName, accountNames := range roleToAccounts {
+		// Create a string of profile names for this role
+		profileListStr := ""
+		for _, acctName := range accountNames {
+			profileListStr += "\"" + acctName + "\", "
+		}
+		profileListStr = strings.Trim(profileListStr, ", ")
+
+		// Add this role to the template data
+		steampipeTemplateData.RoleList = append(steampipeTemplateData.RoleList, SteampipeRole{
+			RoleName:              roleName,
+			RoleProfileListString: profileListStr,
+		})
+	}
+
+	// Debug logging
+	fmt.Println("Found the following Kion roles and accounts:")
+	for roleName, accounts := range roleToAccounts {
+		fmt.Printf("  Role: %s\n", roleName)
+		for _, acct := range accounts {
+			fmt.Printf("    - %s\n", acct)
+		}
+	}
+
+	for _, account := range accounts {
+		steampipeTemplateData.AllAccountsString = steampipeTemplateData.AllAccountsString + "\"aws_" + account.NormalizedAccountName + "\", "
 	}
 
 	steampipeTemplateData.AllAccountsString = strings.Trim(steampipeTemplateData.AllAccountsString, ", ")

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -96,8 +96,8 @@ func Init() {
 		awsTemplate = awsKionTemplate
 
 		// Get Kion URL and API key from global options
-		kionURL := utils.GetGlobalOption("kion-url")
-		kionApikey := utils.GetGlobalOption("kion-apikey")
+		kionURL := globalOpts.GetKionURL()
+		kionApikey := globalOpts.GetKionApikey()
 
 		// Get accounts from Kion
 		fmt.Println("Using Kion as the account source...")

--- a/aws/aws_kion_config.tmpl
+++ b/aws/aws_kion_config.tmpl
@@ -1,0 +1,10 @@
+### {{$.Marker}}_START ###
+
+{{range .AccountList}}
+[profile {{.NormalizedAccountName}}]
+credential_process = kion stak --credential-process --account {{.AccountInfo.AccountId}} --car '{{.KionCloudAccessRoleName}}'
+region = {{$.Params.DefaultRegion}}
+output = {{$.Params.DefaultFormat}}
+{{end}}
+
+### {{$.Marker}}_END ###

--- a/aws/command.go
+++ b/aws/command.go
@@ -9,6 +9,12 @@ import (
 	"github.com/tamu-edu/aiphelper/utils"
 )
 
+// GlobalOptionsProvider is an interface that defines what we need from the main package's GlobalOptions
+type GlobalOptionsProvider interface {
+	GetKionURL() string
+	GetKionApikey() string
+}
+
 type Regions struct {
 	All []string
 }
@@ -18,7 +24,8 @@ type Accounts struct {
 }
 
 var (
-	options *Options
+	options    *Options
+	globalOpts GlobalOptionsProvider
 )
 
 type Options struct {
@@ -33,9 +40,10 @@ type Options struct {
 	FromSSO       bool      `long:"from-sso" description:"Use AWS Identity Center to get account list" group:"account-source"`
 }
 
-func AddCommand(p *flags.Parser) {
+func AddCommand(p *flags.Parser, provider GlobalOptionsProvider) {
 	options = &Options{}
-	options.FromKion = true // Default to Kion
+
+	globalOpts = provider // Store reference to global options provider
 
 	_, err := p.AddCommand("aws", "Initialize AWS", "Initialize AWS config and Steampipe connections", options)
 	if err != nil {
@@ -54,8 +62,8 @@ func (o *Options) Execute(args []string) error {
 
 	if o.FromKion {
 		// Get Kion URL and API key from global options
-		kionURL := utils.GetGlobalOption("kion-url")
-		kionApikey := utils.GetGlobalOption("kion-apikey")
+		kionURL := globalOpts.GetKionURL()
+		kionApikey := globalOpts.GetKionApikey()
 
 		if kionURL == "" {
 			return errors.New("--kion-url is required when using --from-kion")

--- a/aws/command.go
+++ b/aws/command.go
@@ -29,11 +29,43 @@ type Options struct {
 	Accounts      *Accounts `long:"accounts" default:"" description:"Comma-separated list of accounts to tell Steampipe to connect to (default: all accounts assigned to you through SSO)"`
 	DefaultFormat string    `long:"output-format" default:"json" description:"Output format for AWS CLI"`
 	DefaultRegion string    `long:"default-region" default:"us-east-1" description:"Default region for AWS CLI operations"`
+	FromKion      bool      `long:"from-kion" description:"Use Kion API to get AWS account list (default)" group:"account-source"`
+	FromSSO       bool      `long:"from-sso" description:"Use AWS Identity Center to get account list" group:"account-source"`
 }
 
 func AddCommand(p *flags.Parser) {
 	options = &Options{}
-	p.AddCommand("aws", "Initialize AWS", "Initialize AWS", options)
+	options.FromKion = true // Default to Kion
+
+	_, err := p.AddCommand("aws", "Initialize AWS", "Initialize AWS config and Steampipe connections", options)
+	if err != nil {
+		log.Fatalf("Failed to add AWS command: %v", err)
+	}
+}
+
+// Validate checks that the options are valid
+func (o *Options) Execute(args []string) error {
+	// Ensure exactly one account source is selected
+	if o.FromKion == o.FromSSO {
+		return errors.New("you must specify exactly one account source: either --from-kion or --from-sso")
+	}
+
+	// If using Kion, ensure URL and API key are provided
+
+	if o.FromKion {
+		// Get Kion URL and API key from global options
+		kionURL := utils.GetGlobalOption("kion-url")
+		kionApikey := utils.GetGlobalOption("kion-apikey")
+
+		if kionURL == "" {
+			return errors.New("--kion-url is required when using --from-kion")
+		}
+		if kionApikey == "" {
+			return errors.New("--kion-apikey is required when using --from-kion")
+		}
+	}
+
+	return nil
 }
 
 func (r *Regions) UnmarshalFlag(arg string) error {

--- a/aws/command.go
+++ b/aws/command.go
@@ -53,6 +53,9 @@ func AddCommand(p *flags.Parser, provider GlobalOptionsProvider) {
 
 // Validate checks that the options are valid
 func (o *Options) Execute(args []string) error {
+	// Default to Kion
+	o.FromKion = !o.FromSSO
+
 	// Ensure exactly one account source is selected
 	if o.FromKion == o.FromSSO {
 		return errors.New("you must specify exactly one account source: either --from-kion or --from-sso")

--- a/aws/kion.go
+++ b/aws/kion.go
@@ -1,0 +1,162 @@
+package aws
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	ssotypes "github.com/aws/aws-sdk-go-v2/service/sso/types"
+	"github.com/tamu-edu/aiphelper/utils"
+)
+
+// KionTimeField represents a time with validity flag in Kion API responses
+type KionTimeField struct {
+	Time  time.Time `json:"Time"`
+	Valid bool      `json:"Valid"`
+}
+
+// KionCloudAccessRole represents a cloud access role from Kion API
+type KionCloudAccessRole struct {
+	AccountAlias        string        `json:"account_alias"`
+	AccountID           int           `json:"account_id"`
+	AccountName         string        `json:"account_name"`
+	AccountNumber       string        `json:"account_number"`
+	AccountType         string        `json:"account_type"`
+	AccountTypeID       int           `json:"account_type_id"`
+	ApplyToAllAccounts  bool          `json:"apply_to_all_accounts"`
+	AwsIamPath          string        `json:"aws_iam_path"`
+	AwsIamRoleName      string        `json:"aws_iam_role_name"`
+	CloudAccessRoleType string        `json:"cloud_access_role_type"`
+	CreatedAt           KionTimeField `json:"created_at"`
+	DeletedAt           KionTimeField `json:"deleted_at"`
+	FutureAccounts      bool          `json:"future_accounts"`
+	ID                  int           `json:"id"`
+	LongTermAccessKeys  bool          `json:"long_term_access_keys"`
+	Name                string        `json:"name"`
+	ProjectID           int           `json:"project_id"`
+	ShortTermAccessKeys bool          `json:"short_term_access_keys"`
+	UpdatedAt           KionTimeField `json:"updated_at"`
+	WebAccess           bool          `json:"web_access"`
+}
+
+// KionCloudAccessRolesResponse represents the response from the Kion API
+type KionCloudAccessRolesResponse struct {
+	Data   []KionCloudAccessRole `json:"data"`
+	Status int                   `json:"status"`
+}
+
+// GetAccountsFromKion retrieves AWS account information from Kion API
+func GetAccountsFromKion(kionURL, kionApikey string) ([]AWSAccountInfo, error) {
+	if kionURL == "" {
+		return nil, errors.New("kion URL is required when using --from-kion")
+	}
+
+	if kionApikey == "" {
+		return nil, errors.New("kion token is required when using --from-kion")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v3/me/cloud-access-role", kionURL)
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", kionApikey))
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call Kion API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("kion API returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	var kionResp KionCloudAccessRolesResponse
+	if err := json.Unmarshal(body, &kionResp); err != nil {
+		utils.Debug("Kion API response: %s\n", string(body))
+		return nil, fmt.Errorf("failed to unmarshal response: %v", err)
+	}
+
+	var accounts []AWSAccountInfo
+	// uniqueAccounts := make(map[string]bool)
+
+	for _, role := range kionResp.Data {
+		// Skip deleted accounts or non-AWS accounts
+		if role.DeletedAt.Valid || role.AccountTypeID != 1 {
+			continue
+		}
+
+		// Only add each account once (we might see multiple roles per account)
+		// if _, exists := uniqueAccounts[role.AccountNumber]; exists {
+		// 	continue
+		// }
+		// uniqueAccounts[role.AccountNumber] = true
+
+		normalizedAccountName := utils.SnakeCase(fmt.Sprintf("%s_%s", role.AccountName, role.Name))
+
+		if len(normalizedAccountName) > 63 {
+			chars_to_cut := len(normalizedAccountName) - 63
+
+			// Get individual snake_case parts
+			accountNameSnake := utils.SnakeCase(role.AccountName)
+			roleNameSnake := utils.SnakeCase(role.Name)
+
+			// Calculate how much to trim from each part (evenly distribute the cut)
+			accountCut := chars_to_cut / 2
+			roleCut := chars_to_cut - accountCut
+
+			// Make sure we don't trim more characters than available
+			if accountCut > len(accountNameSnake)-3 {
+				accountCut = len(accountNameSnake) - 3
+				roleCut = chars_to_cut - accountCut
+			}
+			if roleCut > len(roleNameSnake)-3 {
+				roleCut = len(roleNameSnake) - 3
+				accountCut = chars_to_cut - roleCut
+			}
+
+			// Apply the trimming
+			trimmedAccountName := accountNameSnake
+			trimmedRoleName := roleNameSnake
+			if accountCut > 0 {
+				trimmedAccountName = accountNameSnake[:len(accountNameSnake)-accountCut]
+			}
+			if roleCut > 0 {
+				trimmedRoleName = roleNameSnake[:len(roleNameSnake)-roleCut]
+			}
+
+			// Create the new normalized name with trimmed parts
+			normalizedAccountName = fmt.Sprintf("%s_%s", trimmedAccountName, trimmedRoleName)
+
+		}
+
+		accountId := role.AccountNumber
+		accountName := role.AccountName
+
+		accountInfo := AWSAccountInfo{
+			NormalizedAccountName:   normalizedAccountName,
+			KionCloudAccessRoleName: role.Name,
+			AccountInfo: ssotypes.AccountInfo{
+				AccountId:    &accountId,
+				AccountName:  &accountName,
+				EmailAddress: nil,
+			},
+		}
+
+		accounts = append(accounts, accountInfo)
+	}
+
+	return accounts, nil
+}

--- a/aws/steampipe.gospc
+++ b/aws/steampipe.gospc
@@ -1,11 +1,21 @@
 ### {{$.Marker}}_START ###
 
-
+{{if .RoleList}}
 {{range .RoleList}}
 connection "aws_role_{{.RoleName}}" {
   plugin      = "aws"
   type        = "aggregator"
   connections = [{{.RoleProfileListString}}]
+  {{- if ne $.RegionsString "" }}
+  regions   = ["{{$.RegionsString}}"]
+  {{- end }}
+}
+{{end}}
+{{else}}
+connection "aws" {
+  plugin      = "aws"
+  type        = "aggregator"
+  connections = [{{$.AllAccountsString}}]
   {{- if ne $.RegionsString "" }}
   regions   = ["{{$.RegionsString}}"]
   {{- end }}

--- a/aws/steampipe.gospc
+++ b/aws/steampipe.gospc
@@ -2,7 +2,7 @@
 
 
 {{range .RoleList}}
-connection "aws_all_{{.RoleName}}" {
+connection "aws_role_{{.RoleName}}" {
   plugin      = "aws"
   type        = "aggregator"
   connections = [{{.RoleProfileListString}}]

--- a/aws/steampipe.gospc
+++ b/aws/steampipe.gospc
@@ -1,28 +1,24 @@
 ### {{$.Marker}}_START ###
 
-connection "aws_all" {
+
+{{range .RoleList}}
+connection "aws_all_{{.RoleName}}" {
   plugin      = "aws"
   type        = "aggregator"
-  connections = [{{.AllAccountsString}}]
+  connections = [{{.RoleProfileListString}}]
   {{- if ne $.RegionsString "" }}
   regions   = ["{{$.RegionsString}}"]
   {{- end }}
 }
+{{end}}
 
 {{range .AccountList}}
-# Account Name: {{.AccountName}}
-# Account Email: {{.EmailAddress}}
-connection "aws_{{.AccountId}}" {
+connection "{{.NormalizedAccountName}}" {
   plugin    = "aws"
-  profile   = "{{.AccountId}}"
+  profile   = "{{.NormalizedAccountName}}"
   {{- if ne $.RegionsString "" }}
   regions   = ["{{$.RegionsString}}"]
   {{- end }}
-}
-connection "aws_{{.NormalizedAccountName}}" {
-  plugin    = "aws"
-  profile   = "{{.NormalizedAccountName}}"
-  regions   = ["{{$.RegionsString}}"]
 }
 {{end}}
 

--- a/main.go
+++ b/main.go
@@ -17,27 +17,25 @@ import (
 
 var Version = "development"
 
-var opts struct {
+type GlobalOptions struct {
 	Version    bool   `long:"version" short:"V" description:"aiphelper Version"`
 	Debug      bool   `long:"debug" short:"d" description:"Enable debug logging"`
-	KionUrl    string `long:"kion-url" description:"Kion URL to use for profile generation" env:"KION_URL"`
+	KionUrl    string `long:"kion-url" description:"Kion URL, i.e.: https://kion.cloud.tamu.edu" env:"KION_URL"`
 	KionApikey string `long:"kion-apikey" description:"Kion API token for authentication" env:"KION_APIKEY"`
 }
+
+var opts GlobalOptions
 
 func main() {
 	p := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
 
-	aws.AddCommand(p)
+	aws.AddCommand(p, &opts)
 	azure.AddCommand(p)
 
 	_, err := p.Parse()
-
+	fmt.Printf("After parsing: KionUrl=%s\n", opts.KionUrl)
 	// Set the debug flag in the utils package
 	utils.DebugEnabled = opts.Debug
-
-	// Store global options
-	utils.SetGlobalOption("kion-url", opts.KionUrl)
-	utils.SetGlobalOption("kion-apikey", opts.KionApikey)
 
 	if opts.Version {
 		fmt.Printf("Version: %s\n", Version)
@@ -55,4 +53,14 @@ func main() {
 	case "azure":
 		azure.Init()
 	}
+}
+
+// GetKionURL implements the GlobalOptionsProvider interface
+func (g *GlobalOptions) GetKionURL() string {
+	return g.KionUrl
+}
+
+// GetKionApikey implements the GlobalOptionsProvider interface
+func (g *GlobalOptions) GetKionApikey() string {
+	return g.KionApikey
 }

--- a/main.go
+++ b/main.go
@@ -18,12 +18,13 @@ import (
 var Version = "development"
 
 var opts struct {
-	Version bool `long:"version" short:"V" description:"aiphelper Version"`
+	Version    bool   `long:"version" short:"V" description:"aiphelper Version"`
 	Debug      bool   `long:"debug" short:"d" description:"Enable debug logging"`
+	KionUrl    string `long:"kion-url" description:"Kion URL to use for profile generation" env:"KION_URL"`
+	KionApikey string `long:"kion-apikey" description:"Kion API token for authentication" env:"KION_APIKEY"`
 }
 
 func main() {
-
 	p := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
 
 	aws.AddCommand(p)
@@ -31,9 +32,14 @@ func main() {
 
 	_, err := p.Parse()
 
-	if opts.Version == true {
 	// Set the debug flag in the utils package
 	utils.DebugEnabled = opts.Debug
+
+	// Store global options
+	utils.SetGlobalOption("kion-url", opts.KionUrl)
+	utils.SetGlobalOption("kion-apikey", opts.KionApikey)
+
+	if opts.Version {
 		fmt.Printf("Version: %s\n", Version)
 		os.Exit(0)
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/tamu-edu/aiphelper/aws"
 	"github.com/tamu-edu/aiphelper/azure"
+	"github.com/tamu-edu/aiphelper/utils"
 )
 
 // https://lightstep.com/blog/getting-real-with-command-line-arguments-and-goflags/
@@ -18,6 +19,7 @@ var Version = "development"
 
 var opts struct {
 	Version bool `long:"version" short:"V" description:"aiphelper Version"`
+	Debug      bool   `long:"debug" short:"d" description:"Enable debug logging"`
 }
 
 func main() {
@@ -30,6 +32,8 @@ func main() {
 	_, err := p.Parse()
 
 	if opts.Version == true {
+	// Set the debug flag in the utils package
+	utils.DebugEnabled = opts.Debug
 		fmt.Printf("Version: %s\n", Version)
 		os.Exit(0)
 	}

--- a/utils/debug.go
+++ b/utils/debug.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"fmt"
+)
+
+// DebugEnabled controls whether debug messages are printed
+var DebugEnabled bool
+
+// Debug prints a message if debug mode is enabled
+func Debug(format string, a ...interface{}) {
+	if DebugEnabled {
+		fmt.Printf("[DEBUG] "+format+"\n", a...)
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,15 +8,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 )
 
 const Marker = "AIPHELPER_MARKER"
-
-var (
-	globalOptions      = make(map[string]string)
-	globalOptionsMutex sync.RWMutex
-)
 
 func SnakeCase(str string) string {
 	str = strings.ToLower(str)
@@ -113,23 +107,4 @@ func CreateOrReplaceInFile(path string, replaceWith string) error {
 func SplitArgumentParser(value string) []string {
 	var delimiter = regexp.MustCompile("[, ] *")
 	return delimiter.Split(value, -1)
-}
-
-// SetGlobalOption sets a global option value
-func SetGlobalOption(name, value string) {
-	globalOptionsMutex.Lock()
-	defer globalOptionsMutex.Unlock()
-	globalOptions[name] = value
-}
-
-// GetGlobalOption retrieves a global option value
-func GetGlobalOption(name string) string {
-	globalOptionsMutex.RLock()
-	value, exists := globalOptions[name]
-	globalOptionsMutex.RUnlock()
-
-	if exists {
-		return value
-	}
-	return ""
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,9 +8,15 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 const Marker = "AIPHELPER_MARKER"
+
+var (
+	globalOptions      = make(map[string]string)
+	globalOptionsMutex sync.RWMutex
+)
 
 func SnakeCase(str string) string {
 	str = strings.ToLower(str)
@@ -107,4 +113,23 @@ func CreateOrReplaceInFile(path string, replaceWith string) error {
 func SplitArgumentParser(value string) []string {
 	var delimiter = regexp.MustCompile("[, ] *")
 	return delimiter.Split(value, -1)
+}
+
+// SetGlobalOption sets a global option value
+func SetGlobalOption(name, value string) {
+	globalOptionsMutex.Lock()
+	defer globalOptionsMutex.Unlock()
+	globalOptions[name] = value
+}
+
+// GetGlobalOption retrieves a global option value
+func GetGlobalOption(name string) string {
+	globalOptionsMutex.RLock()
+	value, exists := globalOptions[name]
+	globalOptionsMutex.RUnlock()
+
+	if exists {
+		return value
+	}
+	return ""
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `aiphelper` tool, including renaming the project, adding support for Kion as an account source, improving AWS and Steampipe profile generation, and refining the command-line interface. These changes aim to expand the tool's functionality, improve usability, and provide clearer documentation.

Resolves #5 and #3.

### Documentation Updates:
* Renamed the project from "AIP SSO Helper" to "AIP Profile Helper" and updated the `README.md` to reflect the new name and expanded functionality.
* Added detailed instructions for using Kion and AWS Identity Center (SSO) as account sources, including examples for AWS CLI and Steampipe usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R91) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R117)
* Updated the `README.md` to include new command-line options, such as `--from-kion` and `--from-sso`, and clarified the profile naming conventions.

### Kion Integration:
* Added support for fetching AWS accounts and roles from Kion using the `--from-kion` option. This includes generating AWS CLI profiles and Steampipe connectors based on Kion data. [[1]](diffhunk://#diff-6fe59643f73b478394f267669c70f00520f5902ea6d880ea1806169a2e687296R71-R110) [[2]](diffhunk://#diff-cf8409717938d12820b8350952e0cc3f02cb1dfaeb80e1e3e53ffe7210e22782R1-R10)
* Introduced a new template (`aws_kion_config.tmpl`) for generating AWS CLI profiles specific to Kion. [[1]](diffhunk://#diff-6fe59643f73b478394f267669c70f00520f5902ea6d880ea1806169a2e687296R37-R39) [[2]](diffhunk://#diff-cf8409717938d12820b8350952e0cc3f02cb1dfaeb80e1e3e53ffe7210e22782R1-R10)

### AWS and Steampipe Enhancements:
* Improved AWS CLI profile generation by normalizing and truncating account and role names. Profiles are now managed within specific file markers to preserve custom configurations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R117) [[2]](diffhunk://#diff-6fe59643f73b478394f267669c70f00520f5902ea6d880ea1806169a2e687296R261-R267)
* Enhanced Steampipe configuration generation by introducing aggregate connectors for roles (when using Kion) and improving naming conventions.

### Codebase Improvements:
* Refactored the `aws.go` and `command.go` files to support the new Kion integration, including adding a `GlobalOptionsProvider` interface for accessing global options like the Kion URL and API key. [[1]](diffhunk://#diff-1b058dc2f8ff2ca864a8dbf4a60b16d37216e9ebb35b3bfd8009f0fd1273700bR12-R17) [[2]](diffhunk://#diff-1b058dc2f8ff2ca864a8dbf4a60b16d37216e9ebb35b3bfd8009f0fd1273700bR39-R79)
* Added debug logging for better visibility into account and role processing during AWS and Steampipe configuration generation.

### Command-Line Interface Updates:
* Introduced new options `--from-kion` and `--from-sso` to specify the account source, ensuring exactly one source is selected. Added validation for required parameters when using Kion.

These changes significantly enhance the functionality and usability of the `aiphelper` tool, making it more versatile for managing AWS and Steampipe configurations across different account sources.